### PR TITLE
add support for "created" attribute on outlines

### DIFF
--- a/listparser.py
+++ b/listparser.py
@@ -266,6 +266,11 @@ class Handler(xml.sax.handler.ContentHandler, xml.sax.handler.ErrorHandler):
         else:
             obj = self.found_urls[url][1]
 
+        # Handle created date
+        obj.setdefault('created', None)
+        if (None, 'created') in attrs.keys():
+            obj.created = _rfc822(attrs[(None, 'created')])
+
         # Handle categories and tags
         obj.setdefault('categories', [])
         if (None, 'category') in attrs.keys():


### PR DESCRIPTION
Outline nodes should support the "created" attribute in the RFC 822 format
http://dev.opml.org/spec2.html#otherSpecialAttributes