### PR TITLE
Use caching in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,43 @@ on:
   - "pull_request"
 
 jobs:
+  build:
+    name: "Build wheel"
+    runs-on: "ubuntu-latest"
+    outputs:
+      wheel-filename: "${{ steps.get-filename.outputs.wheel-filename }}"
+    steps:
+      - name: "Checkout branch"
+        uses: "actions/checkout@v3"
+
+      - name: "Setup Python"
+        id: "setup-python"
+        uses: "actions/setup-python@v4"
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            tox.ini
+            .github/workflows/test.yml
+
+      - name: "Build the project"
+        run: "pip wheel ."
+
+      - name: "Identify the wheel filename"
+        id: "get-filename"
+        run: 'echo "wheel-filename=$(ls -1 *.whl | head -n 1)" >> $GITHUB_OUTPUT'
+
+      - name: "Upload the build artifact"
+        uses: "actions/upload-artifact@v3"
+        with:
+          name: "listparser-${{ github.sha }}.whl"
+          path: "${{ steps.get-filename.outputs.wheel-filename }}"
+          retention-days: 1
+
   test:
+    needs: "build"
+
     strategy:
       matrix:
         os:
@@ -128,9 +164,16 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install tox
 
+
+      - name: "Download the build artifact"
+        uses: "actions/download-artifact@v3"
+        with:
+          name: "listparser-${{ github.sha }}.whl"
+
       - name: "Test (${{ matrix.python.tox-id }}${{ matrix.extras }})"
         # NOTE: The trailing "-ci" marker disables coverage.
         # If the trailing marker ever changes, then update the caching above.
         run: >
           ${{ runner.os == 'Windows' && '.venv\Scripts\tox.exe' || '.venv/bin/tox' }}
+          --installpkg "${{ needs.build.outputs.wheel-filename }}"
           -e ${{ matrix.python.tox-id }}${{ matrix.extras }}-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,13 +88,49 @@ jobs:
         uses: "actions/checkout@v3"
 
       - name: "Setup Python (${{ matrix.python.setup-id }})"
+        id: "setup-python"
         uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python.setup-id }}"
+          # Cache packages that pip downloads.
+          # This does not cache the installed files.
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            tox.ini
+            .github/workflows/test.yml
 
-      - name: "Install Tox"
-        run: "python -m pip install tox"
+      - name: "Restore cache"
+        id: "restore-cache"
+        uses: "actions/cache@v3"
+        with:
+          path: |
+            .venv
+            .tox/${{ matrix.python.tox-id }}${{ matrix.extras }}-ci
+          key: >
+            cache
+            os=${{ matrix.os.id }}
+            python=${{ steps.setup-python.outputs.python-version }}
+            hash=${{ hashFiles('pyproject.toml', 'tox.ini', '.github/workflows/test.yaml') }}
+            tox=${{ matrix.python.tox-id }}${{ matrix.extras }}
+
+      # Possibility 1: Windows
+      - name: "Create a virtual environment (Windows)"
+        if: "${{ steps.restore-cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}"
+        run: |
+          python -m venv .venv
+          .venv\Scripts\pip.exe install tox
+
+      # Possibility 2: Linux or macOS
+      - name: "Create a virtual environment (non-Windows)"
+        if: "${{ steps.restore-cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}"
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install tox
 
       - name: "Test (${{ matrix.python.tox-id }}${{ matrix.extras }})"
         # NOTE: The trailing "-ci" marker disables coverage.
-        run: "tox -e ${{ matrix.python.tox-id }}${{ matrix.extras }}-ci"
+        # If the trailing marker ever changes, then update the caching above.
+        run: >
+          ${{ runner.os == 'Windows' && '.venv\Scripts\tox.exe' || '.venv/bin/tox' }}
+          -e ${{ matrix.python.tox-id }}${{ matrix.extras }}-ci


### PR DESCRIPTION
This change introduces the following improvements:

* Install Tox to a virtual environment (`.venv/`).
* Cache `.venv/` and `.tox/`.
* Pre-build an installable wheel once, then re-use it as an artifact across all tests.

  When running `tox` with multiple `-v` options, additional output showed that `pip` was transforming the listparser `.tar.gz` file to a `.whl` file. On Windows hosts, this was taking 10 seconds to run, but it also affected the setup timings on other hosts by a few seconds.

These changes drop the total CI usage from ~8 minutes to ~5 minutes when there are cache hits (with Windows hosts, the the individual host times can drop by a full minute).