### PR TITLE
Parallelize tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ build
 listparser.egg-info/
 .cache
 htmlcov/
-.coverage
-venv/
+.coverage*
 .idea/
 .venv/
 poetry.lock

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ isolated_build = True
 
 
 [testenv]
+depends =
+    py{311, 310, 39, 38, 37, py3}: coverage_erase
 deps =
     !ci: coverage[toml]
     pytest
@@ -69,6 +71,8 @@ commands = coverage erase
 
 
 [testenv:coverage_report]
+depends =
+    py{311, 310, 39, 38, 37, py3}
 skipsdist = true
 skip_install = true
 deps = coverage[toml]


### PR DESCRIPTION
The tests can now be invoked using `tox p` and will run correctly.

On my machine, the execution time drops from ~175 seconds to ~85 seconds. However, individual test times increase by 2x to 3x. This is likely due to parallel I/O, part of which is the duplicate work pip does in each environment to convert a `.tar.gz` file to a `.whl`.