### PR TITLE
Make Tox build a wheel and share it among environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ lxml = ["lxml"]
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"
 scriv = {extras = ["toml"], version = "^1.0.0"}
-tox = "^4.0.15"
+tox = "^4.3.5"
 
 
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,6 @@
 [tox]
+min_version = 4.3.5
+
 envlist =
     coverage_erase
     py{311, 310, 39, 38, 37}{-http-lxml,}
@@ -14,6 +16,9 @@ isolated_build = True
 
 
 [testenv]
+package = wheel
+wheel_build_env = build_wheel
+
 depends =
     py{311, 310, 39, 38, 37, py3}: coverage_erase
 deps =


### PR DESCRIPTION
This requires tox 4.3.5 due to a bug in how wheels were generated.

Timing tests on Windows from before this patch, and after:

```
           +-------------+------------+
           |    Before   |    After   |
+----------+--------------------------+
| Serial   | 166 seconds | 87 seconds |
| Parallel |  84 seconds | 40 seconds |
+----------+--------------------------+
```

This appears to be due to only one factor: when tox invokes pip, pip doesn't have to convert a .tar.gz file to a wheel. Previously, pip converted the `.tar.gz` file per tox environment.