### PR TITLE
Fix a bug with the tox env dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,20 +150,16 @@ jobs:
             hash=${{ hashFiles('pyproject.toml', 'tox.ini', '.github/workflows/test.yaml') }}
             tox=${{ matrix.python.tox-id }}${{ matrix.extras }}
 
-      # Possibility 1: Windows
-      - name: "Create a virtual environment (Windows)"
-        if: "${{ steps.restore-cache.outputs.cache-hit != 'true' && runner.os == 'Windows' }}"
+      - name: "Identify venv path"
+        shell: "bash"
+        run: "echo 'venv-path=${{ runner.os == 'Windows' && '.venv/Scripts' || '.venv/bin' }}' >> $GITHUB_ENV"
+
+      - name: "Create a virtual environment"
+        if: "steps.restore-cache.outputs.cache-hit == false"
         run: |
           python -m venv .venv
-          .venv\Scripts\pip.exe install tox
-
-      # Possibility 2: Linux or macOS
-      - name: "Create a virtual environment (non-Windows)"
-        if: "${{ steps.restore-cache.outputs.cache-hit != 'true' && runner.os != 'Windows' }}"
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install tox
-
+          ${{ env.venv-path }}/pip install --upgrade pip setuptools wheel
+          ${{ env.venv-path }}/pip install tox
 
       - name: "Download the build artifact"
         uses: "actions/download-artifact@v3"
@@ -174,6 +170,6 @@ jobs:
         # NOTE: The trailing "-ci" marker disables coverage.
         # If the trailing marker ever changes, then update the caching above.
         run: >
-          ${{ runner.os == 'Windows' && '.venv\Scripts\tox.exe' || '.venv/bin/tox' }}
+          ${{ env.venv-path }}/tox run
           --installpkg "${{ needs.build.outputs.wheel-filename }}"
           -e ${{ matrix.python.tox-id }}${{ matrix.extras }}-ci

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ package = wheel
 wheel_build_env = build_wheel
 
 depends =
-    py{311, 310, 39, 38, 37, py3}: coverage_erase
+    py{311, 310, 39, 38, 37, py3}{-http,}{-lxml,}{-minimum_dependencies,}: coverage_erase
 deps =
     !ci: coverage[toml]
     pytest
@@ -77,7 +77,7 @@ commands = coverage erase
 
 [testenv:coverage_report]
 depends =
-    py{311, 310, 39, 38, 37, py3}
+    py{311, 310, 39, 38, 37, py3}{-http,}{-lxml,}{-minimum_dependencies,}
 skipsdist = true
 skip_install = true
 deps = coverage[toml]


### PR DESCRIPTION
Previously, running the tests in parallel (using `tox p`) resulted in a single `.coverage.<xyz>` file remaining after the coverage report was generated.

Root cause appears to be that none of the environments with tox markers were included in the `coverage_report` dependency.

As a result, `coverage_report` only had to wait for the longest-running environment to finish its run.
The `pypy` tox env took so long to finish its runs that other environments (like `py37-minimum_dependencies`) were able to complete before `coverage_report` ran.

However, `pypy3-http` consistently took longer to run than the `pypy` tox env, and it would generate its `.coverage.<xyz>` file after `coverage_report` ran.

This is now fixed by generating all possible tox marker combinations when specifying tox env dependencies.