### PR TITLE
Update pip using the correct CLI invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
         if: "steps.restore-cache.outputs.cache-hit == false"
         run: |
           python -m venv .venv
-          ${{ env.venv-path }}/pip install --upgrade pip setuptools wheel
+          ${{ env.venv-path }}/python -m pip install --upgrade pip setuptools wheel
           ${{ env.venv-path }}/pip install tox
 
       - name: "Download the build artifact"


### PR DESCRIPTION
Fixes a bug in CI on Windows platforms, where `pip.exe` couldn't be overwritten.