### PR TITLE
Use `.yaml` as the consistent YAML file extension

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
             tox.ini
-            .github/workflows/test.yml
+            .github/workflows/test.yaml
 
       - name: "Build the project"
         run: "pip wheel ."
@@ -134,7 +134,7 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
             tox.ini
-            .github/workflows/test.yml
+            .github/workflows/test.yaml
 
       - name: "Restore cache"
         id: "restore-cache"


### PR DESCRIPTION
In addition to renaming `test.yml` to `test.yaml`, this changes two self-referential lines in the file that referred to `test.yml`.