### PR TITLE
Consolidate pythons in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,6 +90,11 @@ jobs:
     name: "Test on ${{ matrix.run.os.name }}"
     runs-on: "${{ matrix.run.os.id }}"
     steps:
+      # The week number is used for cache-busting.
+      - name: "Identify week number"
+        shell: "bash"
+        run: "date +'%V' > week-number.txt"
+
       - name: "Checkout branch"
         uses: "actions/checkout@v3"
 
@@ -102,9 +107,10 @@ jobs:
           # This does not cache the installed files.
           cache: "pip"
           cache-dependency-path: |
+            .github/workflows/test.yaml
             pyproject.toml
             tox.ini
-            .github/workflows/test.yaml
+            week-number.txt
 
       - name: "Restore cache"
         id: "restore-cache"
@@ -113,11 +119,7 @@ jobs:
           path: |
             .venv/
             .tox/
-          key: >
-            cache
-            os=${{ matrix.run.os.id }}
-            python=${{ steps.setup-python.outputs.python-version }}
-            hash=${{ hashFiles('pyproject.toml', 'tox.ini', '.github/workflows/test.yaml') }}
+          key: "cache-os=${{ matrix.run.os.id }}-hash=${{ hashFiles('.github/workflows/test.yaml', 'pyproject.toml', 'tox.ini', 'week-number.txt') }}"
 
       - name: "Identify venv path"
         shell: "bash"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,90 +44,60 @@ jobs:
 
     strategy:
       matrix:
-        os:
-          - name: "Ubuntu"
-            id: "ubuntu-latest"
-        python:
-          - setup-id: "3.11"
-            tox-id: "py311"
-          - setup-id: "3.10"
-            tox-id: "py310"
-          - setup-id: "3.9"
-            tox-id: "py39"
-          - setup-id: "3.8"
-            tox-id: "py38"
-          - setup-id: "3.7"
-            tox-id: "py37"
-        extras:
-          - "-http-lxml"
-
-        include:
-          # Test without extras on Ubuntu.
+        run:
           - os:
-              name: "Ubuntu"
               id: "ubuntu-latest"
-            python:
-              setup-id: "3.7"
-              tox-id: "py37"
-            extras: ""
-
-          # Test minimum dependencies on Ubuntu.
-          - os:
               name: "Ubuntu"
-              id: "ubuntu-latest"
-            python:
-              setup-id: "3.7"
-              tox-id: "py37"
-            extras: "-minimum_dependencies"
-
-          # Test pypy, without extras, on Ubuntu.
-          - os:
-              name: "Ubuntu"
-              id: "ubuntu-latest"
-            python:
-              setup-id: "pypy3.9"
-              tox-id: "pypy39"
-            extras: ""
+            pythons: |
+              pypy3.9
+              3.7
+              3.8
+              3.9
+              3.10
+              3.11
+            tox-environments:
+              - "py311-http-lxml-ci"
+              - "py310-http-lxml-ci"
+              - "py39-http-lxml-ci"
+              - "py38-http-lxml-ci"
+              - "py37-http-lxml-ci"
+              - "py37-ci"
+              - "py37-minimum-dependencies-ci"
+              - "pypy39-ci"
 
           # Test lowest and highest versions on Windows.
           - os:
-              name: "Windows"
               id: "windows-latest"
-            python:
-              setup-id: "3.7"
-              tox-id: "py37"
-          - os:
               name: "Windows"
-              id: "windows-latest"
-            python:
-              setup-id: "3.11"
-              tox-id: "py311"
+            pythons: |
+              3.7
+              3.11
+            tox-environments:
+              - "py311-ci"
+              - "py37-ci"
 
           # Test lowest and highest versions on Mac.
           - os:
               name: "MacOS"
               id: "macos-latest"
-            python:
-              setup-id: "3.7"
-              tox-id: "py37"
-          - os:
-              name: "MacOS"
-              id: "macos-latest"
-            python:
-              setup-id: "3.11"
-              tox-id: "py311"
+            pythons: |
+              3.7
+              3.11
+            tox-environments:
+              - "py37-ci"
+              - "py311-ci"
 
-    name: "Test ${{ matrix.python.tox-id }}${{ matrix.extras }} on ${{ matrix.os.name }}"
-    runs-on: "${{ matrix.os.id }}"
+    name: "Test on ${{ matrix.run.os.name }}"
+    runs-on: "${{ matrix.run.os.id }}"
     steps:
       - name: "Checkout branch"
         uses: "actions/checkout@v3"
 
-      - name: "Setup Python (${{ matrix.python.setup-id }})"
+      - name: "Setup Pythons"
         id: "setup-python"
         uses: "actions/setup-python@v4"
         with:
-          python-version: "${{ matrix.python.setup-id }}"
+          python-version: "${{ matrix.run.pythons }}"
           # Cache packages that pip downloads.
           # This does not cache the installed files.
           cache: "pip"
@@ -141,14 +111,13 @@ jobs:
         uses: "actions/cache@v3"
         with:
           path: |
-            .venv
-            .tox/${{ matrix.python.tox-id }}${{ matrix.extras }}-ci
+            .venv/
+            .tox/
           key: >
             cache
-            os=${{ matrix.os.id }}
+            os=${{ matrix.run.os.id }}
             python=${{ steps.setup-python.outputs.python-version }}
             hash=${{ hashFiles('pyproject.toml', 'tox.ini', '.github/workflows/test.yaml') }}
-            tox=${{ matrix.python.tox-id }}${{ matrix.extras }}
 
       - name: "Identify venv path"
         shell: "bash"
@@ -166,10 +135,8 @@ jobs:
         with:
           name: "listparser-${{ github.sha }}.whl"
 
-      - name: "Test (${{ matrix.python.tox-id }}${{ matrix.extras }})"
-        # NOTE: The trailing "-ci" marker disables coverage.
-        # If the trailing marker ever changes, then update the caching above.
+      - name: "Test"
         run: >
           ${{ env.venv-path }}/tox run
           --installpkg "${{ needs.build.outputs.wheel-filename }}"
-          -e ${{ matrix.python.tox-id }}${{ matrix.extras }}-ci
+          -e ${{ join(matrix.run.tox-environments, ',') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,14 +56,14 @@ jobs:
               3.10
               3.11
             tox-environments:
-              - "py311-http-lxml-ci"
-              - "py310-http-lxml-ci"
-              - "py39-http-lxml-ci"
-              - "py38-http-lxml-ci"
-              - "py37-http-lxml-ci"
-              - "py37-ci"
-              - "py37-minimum-dependencies-ci"
-              - "pypy39-ci"
+              - "py311-http-lxml"
+              - "py310-http-lxml"
+              - "py39-http-lxml"
+              - "py38-http-lxml"
+              - "py37-http-lxml"
+              - "py37"
+              - "py37-minimum-dependencies"
+              - "pypy39"
 
           # Test lowest and highest versions on Windows.
           - os:
@@ -73,8 +73,8 @@ jobs:
               3.7
               3.11
             tox-environments:
-              - "py311-ci"
-              - "py37-ci"
+              - "py37"
+              - "py311"
 
           # Test lowest and highest versions on Mac.
           - os:
@@ -84,8 +84,8 @@ jobs:
               3.7
               3.11
             tox-environments:
-              - "py37-ci"
-              - "py311-ci"
+              - "py37"
+              - "py311"
 
     name: "Test on ${{ matrix.run.os.name }}"
     runs-on: "${{ matrix.run.os.id }}"

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ min_version = 4.3.5
 
 envlist =
     coverage_erase
-    py{311, 310, 39, 38, 37}{-http-lxml,}
-    py37-minimum_dependencies
-    pypy3{-http,}
+    py{311, 310, 39, 38, 37}{-http-lxml,}-coverage
+    py37-minimum_dependencies-coverage
+    pypy3{-http,}-coverage
     coverage_report
     lint
     mypy
@@ -20,9 +20,9 @@ package = wheel
 wheel_build_env = build_wheel
 
 depends =
-    py{311, 310, 39, 38, 37, py3}{-http,}{-lxml,}{-minimum_dependencies,}: coverage_erase
+    py{311, 310, 39, 38, 37, py3}{-http,}{-lxml,}{-minimum_dependencies,}-coverage: coverage_erase
 deps =
-    !ci: coverage[toml]
+    coverage: coverage[toml]
     pytest
     pytest-randomly
 extras =
@@ -32,11 +32,11 @@ commands_pre:
     # The dependencies here must match the minimums declared in `pyproject.toml`.
     minimum_dependencies: {envpython} -m pip install requests==2.25.1 lxml==4.6.2
 commands =
-    # When running locally, use coverage to run the tests.
-    !ci: {envpython} -W error -m coverage run -m pytest --color=yes
+    # If the coverage marker is specified, use coverage to run the tests.
+    coverage: {envpython} -W error -m coverage run -m pytest --color=yes
 
-    # When running in CI, use pytest directly.
-    ci: {envpython} -W error -m pytest
+    # If the coverage marker is not specified (like in CI), use pytest directly.
+    !coverage: {envpython} -W error -m pytest
 
 
 [testenv:lint]
@@ -77,7 +77,7 @@ commands = coverage erase
 
 [testenv:coverage_report]
 depends =
-    py{311, 310, 39, 38, 37, py3}{-http,}{-lxml,}{-minimum_dependencies,}
+    py{311, 310, 39, 38, 37, py3}{-http,}{-lxml,}{-minimum_dependencies,}-coverage
 skipsdist = true
 skip_install = true
 deps = coverage[toml]


### PR DESCRIPTION
This modifies CI so that all of the tox environments for each OS are run on the same job, rather than each Python version and tox environment into separate jobs.

This reduces CI usage from 4m33s to 2m03s with cache hits.