### PR TITLE
Update mypy comments

### DIFF
--- a/changelog.d/20230227_095748_kurtmckee_update_mypy_comments.rst
+++ b/changelog.d/20230227_095748_kurtmckee_update_mypy_comments.rst
@@ -1,0 +1,9 @@
+Changed
+-------
+
+*   Restrict type-ignore comments to only exactly what's required to suppress a mypy error.
+
+Development
+-----------
+
+*   Remove type-ignore comments from the test suite, which is no longer checked by mypy.

--- a/src/listparser/__init__.py
+++ b/src/listparser/__init__.py
@@ -12,12 +12,12 @@ try:
     import requests
     import urllib3.exceptions
 except ImportError:
-    requests = None  # type: ignore
-    urllib3 = None  # type: ignore
+    requests = None  # type: ignore[assignment]
+    urllib3 = None  # type: ignore[assignment]
 
 try:
     # lxml lacks mypy stubs at the time of writing.
-    import lxml.etree  # type: ignore
+    import lxml.etree  # type: ignore[import]
 except ImportError:
     lxml = None
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -12,7 +12,7 @@ import listparser
 try:
     import requests
 except ImportError:
-    requests = None  # type: ignore
+    requests = None
 
 
 empty_doc = '<?xml version="1.0"?><opml />'

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -21,7 +21,7 @@ def use_dict():
 
 
 def test_return_guarantees(use_dict):
-    result = listparser.parse(0)  # type: ignore
+    result = listparser.parse(0)
     assert result["bozo"]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy==1.0.0
+    mypy==1.0.1
     types-requests
     types-toml
 commands = mypy


### PR DESCRIPTION
Changed
-------

*   Restrict type-ignore comments to only exactly what's required to suppress a mypy error.

Development
-----------

*   Remove type-ignore comments from the test suite, which is no longer checked by mypy.
