### PR TITLE
Remove standalone linting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,8 +143,8 @@ jobs:
           -e ${{ join(matrix.run.tox-environments, ',') }}
 
 
-  lint:
-    name: "Lint"
+  quality:
+    name: "Quality"
     runs-on: "ubuntu-latest"
     needs: "build"
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,6 @@ repos:
     hooks:
       - id: black
 
-      # Allow tox to run black as a test.
-      - id: black
-        alias: black-check
-        name: black (check)
-        stages: [manual]
-        args: [--check]
-
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
@@ -36,13 +29,6 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-
-      # Allow tox to run isort as a test.
-      - id: isort
-        alias: isort-check
-        name: isort (check)
-        stages: [manual]
-        args: [--check]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist =
     py38-minimum_dependencies-coverage
     pypy3{-http,}-coverage
     coverage_report
-    lint
     mypy
     docs
 
@@ -37,16 +36,6 @@ commands =
 
     # If the coverage marker is not specified (like in CI), use pytest directly.
     !coverage: {envpython} -W error -m pytest
-
-
-[testenv:lint]
-skipsdist = true
-skip_install = true
-deps = pre-commit
-commands =
-    pre-commit run --all-files --hook-stage manual black-check
-    pre-commit run --all-files --hook-stage manual flake8
-    pre-commit run --all-files --hook-stage manual isort-check
 
 
 [testenv:mypy]


### PR DESCRIPTION
This eliminates some of the configuration that is no longer needed due to integration with pre-commit's CI service.