### PR TITLE
Explicitly specify the documentation HTML theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,3 +42,9 @@ exclude_trees = ()
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
+
+
+# HTML theme configuration
+# ------------------------
+
+html_theme = "alabaster"


### PR DESCRIPTION
Read the Docs introduced a change last week which appended code to `conf.py` during builds. The appended code assumed `html_theme` was defined, which resulted in `NameError` getting raised.

They've fixed their code to avoid `NameError`, but this PR adds `html_theme` explicitly to avoid relying on defaults in both Sphinx and in Read the Docs.