### PR TITLE
Migrate to Poetry's `package-mode` option

### DIFF
--- a/requirements/docs/pyproject.toml
+++ b/requirements/docs/pyproject.toml
@@ -1,10 +1,6 @@
+[tool.poetry]
+package-mode = false
+
 [tool.poetry.dependencies]
 python = ">=3.8"
 sphinx = "*"
-
-
-[tool.poetry]
-name = ""
-version = "0"
-description = ""
-authors = []

--- a/requirements/mypy/pyproject.toml
+++ b/requirements/mypy/pyproject.toml
@@ -1,13 +1,9 @@
+[tool.poetry]
+package-mode = false
+
 [tool.poetry.dependencies]
 python = ">=3.8"
 mypy = "*"
 lxml-stubs = "*"
 types-requests = "*"
 types-toml = "*"
-
-
-[tool.poetry]
-name = ""
-version = "0"
-description = ""
-authors = []

--- a/requirements/test/pyproject.toml
+++ b/requirements/test/pyproject.toml
@@ -1,12 +1,8 @@
+[tool.poetry]
+package-mode = false
+
 [tool.poetry.dependencies]
 python = ">=3.8"
 coverage = {extras = ["toml"], version = "*"}
 pytest = "*"
 pytest-randomly = "*"
-
-
-[tool.poetry]
-name = ""
-version = "0"
-description = ""
-authors = []


### PR DESCRIPTION

This PR migrates the dummy package values in `requirements/*/pyproject.toml` files to Poetry's new `package-mode = false` option.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>