### PR TITLE
Drop support for PyPy 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,6 @@ jobs:
               - "3.13"
             cpython-beta: "3.14"
             pypys:
-              - "3.10"
               - "3.11"
             tox-post-environments:
               - "py3.9-minimum_dependencies"

--- a/changelog.d/20250707_083312_kurtmckee_pypy_3_11_only.rst
+++ b/changelog.d/20250707_083312_kurtmckee_pypy_3_11_only.rst
@@ -1,0 +1,4 @@
+Python support
+--------------
+
+*   Drop support for PyPy 3.10.

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ min_version = 4.3.5
 envlist =
     coverage_erase
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}{-http-lxml,}
-    pypy{3.11, 3.10}{-http,}
+    pypy{3.11}{-http,}
     py3.9-minimum_dependencies
     coverage_report
     build
@@ -20,7 +20,7 @@ wheel_build_env = build_wheel
 
 depends =
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}{-http,}{-lxml,}{-minimum_dependencies,}: coverage_erase
-    pypy{3.11, 3.10}{-http,}: coverage_erase
+    pypy{3.11}{-http,}: coverage_erase
 deps =
     -rrequirements/test/requirements.txt
     # The dependencies here must match the minimums declared in `pyproject.toml`.
@@ -68,7 +68,7 @@ commands = coverage erase
 [testenv:coverage_report]
 depends =
     py{3.14, 3.13, 3.12, 3.11, 3.10, 3.9}{-http,}{-lxml,}{-minimum_dependencies,}
-    pypy{3.11, 3.10}{-http,}
+    pypy{3.11}{-http,}
 skipsdist = true
 skip_install = true
 deps = -rrequirements/test/requirements.txt


### PR DESCRIPTION

Python support
--------------

*   Drop support for PyPy 3.10.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>